### PR TITLE
Memory leak issue

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -3224,7 +3224,10 @@ func (v *GtkTextBuffer) GetText(iter *GtkTextIter, start *GtkTextIter, end *GtkT
 	return C.GoString(C.to_charptr(C._gtk_text_buffer_get_text(v.TextBuffer, &start.TextIter, &end.TextIter, bool2gboolean(include_hidden_chars))))
 }
 func (v *GtkTextBuffer) GetSlice(start *GtkTextIter, end *GtkTextIter, include_hidden_chars bool) string {
-	return C.GoString(C.to_charptr(C._gtk_text_buffer_get_slice(v.TextBuffer, &start.TextIter, &end.TextIter, bool2gboolean(include_hidden_chars))))
+	pchar := C.to_charptr(C._gtk_text_buffer_get_slice(v.TextBuffer, &start.TextIter, &end.TextIter, bool2gboolean(include_hidden_chars)))
+	result_string := C.GoString(pchar)
+	C.free(unsafe.Pointer(pchar))
+	return result_string
 }
 func (v *GtkTextBuffer) InsertPixbuf(iter *GtkTextIter, pixbuf *gdkpixbuf.GdkPixbuf) {
 	C._gtk_text_buffer_insert_pixbuf(v.TextBuffer, &iter.TextIter, pixbuf.Pixbuf)


### PR DESCRIPTION
As I mentioned by email there is a memory leak in GtkTexBuffer.GetSlice method. Please take a look at this tiny change and confirm that I am fixing it right. Then I will probably fix some other memory leak issues in go-gtk bindings.
