### PR TITLE
Some methods

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -4308,7 +4308,16 @@ func (v *GtkTreeView) CollapseAll() {
 //gboolean gtk_tree_view_row_expanded (GtkTreeView *tree_view, GtkTreePath *path);
 //void gtk_tree_view_set_reorderable (GtkTreeView *tree_view, gboolean reorderable);
 //gboolean gtk_tree_view_get_reorderable (GtkTreeView *tree_view);
-//void gtk_tree_view_set_cursor (GtkTreeView *tree_view, GtkTreePath *path, GtkTreeViewColumn *focus_column, gboolean start_editing);
+func (v *GtkTreeView) SetCursor(path *GtkTreePath, col *GtkTreeViewColumn, se bool) {
+	var pcol *C.GtkTreeViewColumn
+	if nil == col {
+		pcol = nil
+	} else {
+		pcol = col.TreeViewColumn
+	}
+	C.gtk_tree_view_set_cursor(C.to_GtkTreeView(v.Widget), path.TreePath,
+		pcol, bool2gboolean(se))
+}
 //void gtk_tree_view_set_cursor_on_cell (GtkTreeView *tree_view, GtkTreePath *path, GtkTreeViewColumn *focus_column, GtkCellRenderer *focus_cell, gboolean start_editing);
 //void gtk_tree_view_get_cursor (GtkTreeView *tree_view, GtkTreePath **path, GtkTreeViewColumn **focus_column);
 func (v *GtkTreeView) GetCursor(path **GtkTreePath, focus_column **GtkTreeViewColumn) {


### PR DESCRIPTION
Nothing significant.
ToGtkWidget method looks very strange, I agree. It is required since cgo is stupid and treats variable of type C.GtkWidget not equal to gtk.C.GtkWidget. You can look at file_tree/file_tree.go in tabby repo for how it is used.
