### PR TITLE
Ensure GdkWindow.GetNativeWindowID is available on Darwin.

### DIFF
--- a/gdk/gdk_darwin.go
+++ b/gdk/gdk_darwin.go
@@ -1,0 +1,1 @@
+gdk_linux.go


### PR DESCRIPTION
go-gtk currently doesn't build on OS X, since GdkWindow.GetNativeWindowID is not defined on that platform. Since most Gtk+ users on Mac use the the X11 version of Gtk+, simply using the same definition as on Linux allows one to compile go-gtk on OS X.
