### PR TITLE
Fix gdk.EventKey for tip

### DIFF
--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -2725,17 +2725,17 @@ type EventAny struct {
 }
 
 type EventKey struct {
-	Type            int
+	Type            C.int
 	Window          unsafe.Pointer
 	SendEvent       int8
 	Time            uint32
-	State           uint
-	Keyval          uint
+	State           C.unsigned
+	Keyval          C.unsigned
 	Length          int
 	String          *uint8
 	HardwareKeycode uint16
 	Group           uint8
-	IsModifier      uint
+	IsModifier      C.unsigned
 }
 
 type EventButton struct {


### PR DESCRIPTION
Tip has C.int (32 bits), int (64 bits) on amd64. This fixes it for EventKey. Other things will probably also need fixes. 
