### PR TITLE
Add Ref() and Unref() to GdkPixbuf

### DIFF
--- a/gdkpixbuf/gdkpixbuf.go
+++ b/gdkpixbuf/gdkpixbuf.go
@@ -91,6 +91,14 @@ func (p *Pixbuf) GetHeight() int {
 	return int(C.gdk_pixbuf_get_height(C.toGdkPixbuf(unsafe.Pointer(p.GPixbuf))))
 }
 
+func (p *Pixbuf) Ref() {
+	C.g_object_ref(C.gpointer(p.GPixbuf))
+}
+
+func (p *Pixbuf) Unref() {
+	C.g_object_unref(C.gpointer(p.GPixbuf))
+}
+
 //-----------------------------------------------------------------------
 // Animation
 //-----------------------------------------------------------------------


### PR DESCRIPTION
This just gives a quick api so that a user doesn't have to import `unsafe`, pass it to `glib.ObjectFromNative()` etc to fire reference functions on pixbufs.
