### PR TITLE
Added GetIndices function to TreePath type.

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -3872,7 +3872,22 @@ func (v *TreePath) GetDepth() int {
 	return int(C.gtk_tree_path_get_depth(v.GTreePath))
 }
 
-// gtk_tree_path_get_indices
+func (v *TreePath) GetIndices() []int {
+	depth := v.GetDepth()
+	idx := make([]int, depth)
+
+	var gint_size_help C.gint
+	addr := uintptr(unsafe.Pointer(C.gtk_tree_path_get_indices(v.GTreePath)))
+	size := unsafe.Sizeof(gint_size_help)
+
+	for i := 0; i < depth; i++ {
+		idx[i] = int(*((*C.gint)(unsafe.Pointer(addr))))
+		addr += size
+	}
+
+	return idx
+}
+
 // gtk_tree_path_get_indices_with_depth //since 2.22
 
 func (v *TreePath) Free() {


### PR DESCRIPTION
Hi,

I added a Go wrapper for the [gtk_tree_path_get_indices](http://www.gtk.org/api/2.6/gtk/GtkTreeModel.html#gtk-tree-path-get-indices) function.

This code converts a C array of `gint` to a Go `[]int` slice. I'm not quite sure, if this is the correct way of reading/converting a C array with cgo, but it seems to work fine. If there is a better way, please let me know, and I'll implement it.
