### PR TITLE
fixed deprecation warnings of GtkComboBoxEntry and GtkComboBox methods

### DIFF
--- a/example/demo/demo.go
+++ b/example/demo/demo.go
@@ -225,7 +225,7 @@ func main() {
 	// GtkComboBoxEntry
 	//--------------------------------------------------------
 	combos := gtk.NewHBox(false, 1)
-	comboboxentry := gtk.NewComboBoxEntryNewText()
+	comboboxentry := gtk.NewComboBoxText()
 	comboboxentry.AppendText("Monkey")
 	comboboxentry.AppendText("Tiger")
 	comboboxentry.AppendText("Elephant")
@@ -237,7 +237,7 @@ func main() {
 	//--------------------------------------------------------
 	// GtkComboBox
 	//--------------------------------------------------------
-	combobox := gtk.NewComboBoxNewText()
+	combobox := gtk.NewComboBoxText()
 	combobox.AppendText("Peach")
 	combobox.AppendText("Banana")
 	combobox.AppendText("Apple")


### PR DESCRIPTION
gtk_combo_box_entry_new_text() is deprecated since gtk 2.24
gtk_combo_box_new_text() is deprecated since gtk 2.24
