### PR TITLE
gtk/gtk.go 6342 : Fix: return nil

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -6347,9 +6347,8 @@ func (v *UIManager) AddUIFromString(buffer string) error {
 	if gerror != nil {
 		err := glib.ErrorFromNative(unsafe.Pointer(gerror))
 		return err
-	} else {
-		return nil
-	}
+	} 
+	return nil
 }
 
 // gtk_ui_manager_add_ui_from_file


### PR DESCRIPTION
go version go1.0.2 - error when go get.

On line 6342, Go needs a  return statment
