### PR TITLE
Fix glib build

### DIFF
--- a/glib/glib.go
+++ b/glib/glib.go
@@ -753,7 +753,7 @@ func NewMainContext() *GMainContext {
 }
 
 func (v *GMainContext) Ref() *GMainContext {
-	return &GMainContext{C.g_main_loop_ref(v.MainContext)}
+	return &GMainContext{C.g_main_context_ref(v.MainContext)}
 }
 
 func (v *GMainContext) Unref() {


### PR DESCRIPTION
Build fails with git tip (most likely due to https://code.google.com/p/go/source/detail?r=a70a32dc121a).

```
$ go build
# github.com/agl/go-gtk/glib
./glib.go:814: cannot use v.MainContext (type *C.GMainContext) as type *C.GMainLoop in function argument
./glib.go:814: cannot use _Cfunc_g_main_loop_ref(v.MainContext) (type *C.GMainLoop) as type *C.GMainContext in field value
```
