### PR TITLE
Add WaitForImage to Clipboard, implementing gtk_clipboard_wait_for_image()

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -360,6 +360,10 @@ func (v *Clipboard) Store() {
 	C.gtk_clipboard_store(v.GClipboard)
 }
 
+func (v *Clipboard) WaitForImage() *gdkpixbuf.Pixbuf {
+	return (*gdkpixbuf.Pixbuf)(unsafe.Pointer(C.gtk_clipboard_wait_for_image(v.GClipboard)))
+}
+
 func (v *Clipboard) WaitForText() string {
 	return gostring(C.gtk_clipboard_wait_for_text(v.GClipboard))
 }

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -361,7 +361,11 @@ func (v *Clipboard) Store() {
 }
 
 func (v *Clipboard) WaitForImage() *gdkpixbuf.Pixbuf {
-	return (*gdkpixbuf.Pixbuf)(unsafe.Pointer(C.gtk_clipboard_wait_for_image(v.GClipboard)))
+	gpixbuf := C.gtk_clipboard_wait_for_image(v.GClipboard)
+	return &gdkpixbuf.Pixbuf{
+		GdkPixbuf: gdkpixbuf.NewGdkPixbuf(unsafe.Pointer(gpixbuf)),
+		GObject:   glib.ObjectFromNative(unsafe.Pointer(gpixbuf)),
+	}
 }
 
 func (v *Clipboard) WaitForText() string {


### PR DESCRIPTION
Implement gtk_clipboard_wait_for_image(), since only gtk_clipboard_wait_for_text() was implemented already.