### PR TITLE
Drops support to X11 on Mac OS X by default

### DIFF
--- a/gdk/gdk_darwin.go
+++ b/gdk/gdk_darwin.go
@@ -1,1 +1,0 @@
-gdk_linux.go

--- a/gdk/gdk_quartz_darwin.go
+++ b/gdk/gdk_quartz_darwin.go
@@ -1,0 +1,33 @@
+// +build !with-x11
+
+package gdk
+
+/*
+#cgo pkg-config: gdk-2.0 gthread-2.0
+#cgo CFLAGS: -x objective-c
+
+#include <gdk/gdk.h>
+#include <gdk/gdkquartz.h>
+
+// Must return void* to avoid "struct size calculation error off=8 bytesize=0"
+// See:
+// - https://github.com/golang/go/issues/12065
+// - http://thread0.me/2015/07/gogoa-cocoa-bindings-for-go/
+void* getNsWindow(GdkWindow *w) {
+	return (void*) gdk_quartz_window_get_nswindow(w);
+}
+
+*/
+import "C"
+
+import "unsafe"
+
+type NSWindow struct {
+	ID unsafe.Pointer
+}
+
+func (v *Window) GetNativeWindow() *NSWindow {
+	return &NSWindow{
+		unsafe.Pointer(C.getNsWindow(v.GWindow)),
+	}
+}

--- a/gdk/gdk_x11_darwin.go
+++ b/gdk/gdk_x11_darwin.go
@@ -1,0 +1,16 @@
+// +build with-x11
+
+package gdk
+
+/*
+#cgo pkg-config: gdk-2.0 gthread-2.0
+
+#include <gdk/gdk.h>
+#include <gdk/gdkx.h>
+*/
+import "C"
+import "unsafe"
+
+func (v *Window) GetNativeWindowID() int32 {
+	return int32(C.gdk_x11_drawable_get_xid((*C.GdkDrawable)(unsafe.Pointer(v.GWindow))))
+}

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -1409,10 +1409,6 @@ func (v *Window) Resize(width int, height int) {
 	C.gtk_window_resize(WINDOW(v), gint(width), gint(height))
 }
 
-func (v *Window) XID() int32 {
-	return gdk.WindowFromUnsafe(unsafe.Pointer(v.GWidget.window)).GetNativeWindowID()
-}
-
 // gtk_window_set_default_icon_list
 // gtk_window_set_default_icon
 // gtk_window_set_default_icon_from_file

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -6,7 +6,9 @@
 #ifdef _WIN32
 #include <windows.h>
 #else
-#include <gdk/gdkx.h>
+//Why is this necessary?
+//#include <gdk/gdkx.h>
+//#include <gdk/gdkquartz.h>
 #endif
 #include <unistd.h>
 #include <stdlib.h>

--- a/gtk/gtk_x11.go
+++ b/gtk/gtk_x11.go
@@ -1,0 +1,13 @@
+// +build with-x11
+
+package gtk
+
+import (
+	"unsafe"
+
+	"github.com/mattn/go-gtk/gdk"
+)
+
+func (v *Window) XID() int32 {
+	return gdk.WindowFromUnsafe(unsafe.Pointer(v.GWidget.window)).GetNativeWindowID()
+}


### PR DESCRIPTION
Homebrew has dropped support to X11 on every GTK+ related formula since
(https://github.com/Homebrew/homebrew/pull/39868). This change reflects this
decision on go-gtk.

By default, builds without support to X11. X11 support can be enabled by using
the build flag `with-x11` for users containing a GTK+ installation with X11
support.

Fixes #245