### PR TITLE
Changes on gtkrc, TreeModel and deprecated method calls

### DIFF
--- a/gdk/gdk.go
+++ b/gdk/gdk.go
@@ -321,7 +321,18 @@ func (v *GC) SetRgbBgColor(color *Color) {
 	C.gdk_gc_set_rgb_bg_color(v.GGC, &color.GColor)
 }
 
+//-----------------------------------------------------------------------
+// GdkScreen
+//-----------------------------------------------------------------------
+type Screen struct {
+	GScreen *C.GdkScreen
+}
+
 // GdkScreen * gdk_gc_get_screen (GdkGC *gc);
+
+func GetDefaultScreen() (screen *Screen) {
+	return &Screen{GScreen: C.gdk_screen_get_default()}
+}
 
 func ScreenWidth() (width int) {
 	return int(C.gdk_screen_width())

--- a/gtk/gtk.go.h
+++ b/gtk/gtk.go.h
@@ -813,6 +813,7 @@ static inline GtkScrolledWindow* toGScrolledWindow(GtkWidget* w) { return GTK_SC
 static inline GtkViewport* toGViewport(GtkWidget* w) { return GTK_VIEWPORT(w); }
 static inline GtkWidget* toGWidget(void* w) { return GTK_WIDGET(w); }
 static inline GdkWindow* toGdkWindow(void* w) { return GDK_WINDOW(w); }
+static inline GdkScreen* toGdkScreen(void* s) { return GDK_SCREEN(s); }
 static inline GtkTreeView* toGTreeView(GtkWidget* w) { return GTK_TREE_VIEW(w); }
 static inline GtkIconView* toGIconView(GtkWidget* w) { return GTK_ICON_VIEW(w); }
 static inline GtkTreeSortable* toGTreeSortable(GtkTreeModel* m) { return GTK_TREE_SORTABLE(m); }


### PR DESCRIPTION
Added methods for the reloading and resetting of gtkrc styles, implemented two methods to get the TreeModel and all selected rows on this model and finally updated two deprecated method calls.