### PR TITLE
gtk_dialog_response() binding

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -1118,6 +1118,10 @@ func (v *Dialog) Run() ResponseType {
 }
 
 func (v *Dialog) Response(response interface{}, datas ...interface{}) {
+	if id, ok := response.(ResponseType); ok {
+		C.gtk_dialog_response(DIALOG(v), gint(int(id)))
+		return
+	}
 	v.Connect("response", response, datas...)
 }
 


### PR DESCRIPTION
I think It's better (*Dialog) Response() map to C.gtk_dialog_response().
Otherwise we need to define it as another name.