### PR TITLE
Correct implementation of NewPixbufFromData via gdk_pixbuf_new_from_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@
 
   * http://www.gtk.org/download/windows.php
 
+## EMBEDDING
+
+  It is possible to embed a pixbuf image with:
+  ```sh
+  $ go run tools/make_inline_pixbuf/make_inline_pixbuf.go logoPNG data/go-gtk-logo.png > logo.gen.go
+  ```
+  
+  And then load it with:
+  ```go
+	pb := gdkpixbuf.NewPixbufFromData(logoPNG)
+  ```
+
 ## LICENSE
 
   The library is available under the same terms and conditions as the Go, the BSD style license, and the LGPL (GNU Lesser General Public License). The idea is that if you can use Go (and Gtk) in a project, you should also be able to use go-gtk.
@@ -62,6 +74,7 @@
   * matiaslina
   * Dag Robøle
   * Denis Dyakov
+  * Giuseppe Mazzotta
 
 ## GOAL
 

--- a/gdkpixbuf/gdkpixbuf.go
+++ b/gdkpixbuf/gdkpixbuf.go
@@ -142,21 +142,20 @@ func NewPixbufFromFileAtScale(filename string, width, height int, preserve_aspec
 }
 
 // NewPixbufFromData creates a Pixbuf from image data in a byte array
-//
-// Can be used for reading Base64 encoded images easily with the output from base64.StdEncoding.DecodeString("...")
-func NewPixbufFromData(buffer []byte) (*Pixbuf, *glib.Error) {
-	var err *C.GError
-	loader := C.gdk_pixbuf_loader_new()
-	C.gdk_pixbuf_loader_write(loader, C.to_gucharptr(unsafe.Pointer(&buffer[0])), C.gsize(len(buffer)), &err)
-	gpixbuf := C.gdk_pixbuf_loader_get_pixbuf(loader)
-
-	if err != nil {
-		return nil, glib.ErrorFromNative(unsafe.Pointer(err))
-	}
+func NewPixbufFromData(data []byte, colorspace Colorspace, hasAlpha bool, bitsPerSample, width, height, rowStride int) *Pixbuf {
+	gpixbuf := C.gdk_pixbuf_new_from_data(
+		C.to_gucharptr(unsafe.Pointer(&data[0])),
+		C.GdkColorspace(colorspace),
+		gbool(hasAlpha),
+		C.int(bitsPerSample),
+		C.int(width),
+		C.int(height),
+		C.int(rowStride),
+		nil, nil)
 	return &Pixbuf{
 		GdkPixbuf: &GdkPixbuf{gpixbuf},
 		GObject:   glib.ObjectFromNative(unsafe.Pointer(gpixbuf)),
-	}, nil
+	}
 }
 
 // NewPixbufFromBytes creates a Pixbuf from image data in a byte array

--- a/gdkpixbuf/gdkpixbuf.go
+++ b/gdkpixbuf/gdkpixbuf.go
@@ -12,6 +12,14 @@ import (
 	"unsafe"
 )
 
+// PixbufData is an inline/embedded image data object for usage with NewPixbufFromData.
+type PixbufData struct {
+	Data []byte
+	Colorspace Colorspace
+	HasAlpha bool
+	BitsPerSample, Width, Height, RowStride int
+}
+
 func gstring(s *C.char) *C.gchar { return C.toGstr(s) }
 func cstring(s *C.gchar) *C.char { return C.toCstr(s) }
 func gostring(s *C.gchar) string { return C.GoString(cstring(s)) }
@@ -142,15 +150,15 @@ func NewPixbufFromFileAtScale(filename string, width, height int, preserve_aspec
 }
 
 // NewPixbufFromData creates a Pixbuf from image data in a byte array
-func NewPixbufFromData(data []byte, colorspace Colorspace, hasAlpha bool, bitsPerSample, width, height, rowStride int) *Pixbuf {
+func NewPixbufFromData(pbd PixbufData) *Pixbuf {
 	gpixbuf := C.gdk_pixbuf_new_from_data(
-		C.to_gucharptr(unsafe.Pointer(&data[0])),
-		C.GdkColorspace(colorspace),
-		gbool(hasAlpha),
-		C.int(bitsPerSample),
-		C.int(width),
-		C.int(height),
-		C.int(rowStride),
+		C.to_gucharptr(unsafe.Pointer(&pbd.Data[0])),
+		C.GdkColorspace(pbd.Colorspace),
+		gbool(pbd.HasAlpha),
+		C.int(pbd.BitsPerSample),
+		C.int(pbd.Width),
+		C.int(pbd.Height),
+		C.int(pbd.RowStride),
 		nil, nil)
 	return &Pixbuf{
 		GdkPixbuf: &GdkPixbuf{gpixbuf},

--- a/tools/make_inline_pixbuf/make_inline_pixbuf.go
+++ b/tools/make_inline_pixbuf/make_inline_pixbuf.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mattn/go-gtk/gdkpixbuf"
+	"github.com/mattn/go-gtk/gtk"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintf(os.Stderr, "Usage: make-inline-pixbuf resourceName input > output\n")
+		os.Exit(1)
+	}
+
+	image := gtk.NewImageFromFile(os.Args[2])
+	pb := image.GetPixbuf()
+	if pb.GetWidth() == -1 {
+		fmt.Fprintf(os.Stderr, "ERROR: invalid pixbuf image\n")
+		os.Exit(2)
+	}
+
+	var pbd gdkpixbuf.PixbufData
+	pbd.Data = pb.GetPixelsWithLength()
+	pbd.Width, pbd.Height, pbd.RowStride, pbd.HasAlpha = pb.GetWidth(), pb.GetHeight(), pb.GetRowstride(), pb.GetHasAlpha()
+	pbd.Colorspace, pbd.BitsPerSample = pb.GetColorspace(), pb.GetBitsPerSample()
+
+	fmt.Printf("package main \n\nimport \"github.com/mattn/go-gtk/gdkpixbuf\"\n\nvar (\n")
+	fmt.Printf("\t%s = %#v\n", os.Args[1], pbd)
+
+	fmt.Println(")\n")
+}


### PR DESCRIPTION
The current implementation of `NewPixbufFromData` seems using some assumptions about how `gdk_pixbuf_loader_write` should work, and anyway does not document properly how to use it. (we probably should have tests for these functions).

After some struggles I individuated in `gdk_pixbuf_new_from_data` the correct API counterpart for it.

This PR uses `gdk_pixbuf_new_from_data` instead of `gdk_pixbuf_loader_write` and additionally defines a `PixbufData` struct for embedding/inlining of pixbuf data from files; additionally, a CLI tool (to be used with `//go:generate`) is provided in `tools/` to generate such pixbuf data automatically.

Inspiration for the embedding/inlining approach: https://github.com/krh/gtk/blob/master/gdk-pixbuf/make-inline-pixbuf.c

Upstream documentation: https://developer.gnome.org/gdk-pixbuf/stable/gdk-pixbuf-Image-Data-in-Memory.html#gdk-pixbuf-new-from-data