### PR TITLE
Comboboxtext entry access

### DIFF
--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -6244,6 +6244,11 @@ func (v *ComboBoxText) GetActiveText() string {
 	return gostring(C._gtk_combo_box_text_get_active_text(COMBO_BOX_TEXT(v)))
 }
 
+func (v *ComboBoxText) GetEntry() *Entry {
+	w := v.GetChild()
+	return &Entry{*w, Editable{C.toGEditable(w.GWidget)}}
+}
+
 //-----------------------------------------------------------------------
 // GtkComboBoxEntry
 //-----------------------------------------------------------------------

--- a/gtk/gtk.go
+++ b/gtk/gtk.go
@@ -5889,10 +5889,11 @@ func (v *ListStore) MoveAfter(iter *TreeIter, position *TreeIter) {
 
 //TODO instead of using this methods to change between treemodel and liststore, is better to usa an interface ITreeModel
 //nb: ListStore e TreeStore sono un TreeModel (implementano GtkTreeModel!)
-/*func (v *GtkListStore) ToTreeModel() *GtkTreeModel {
+func (v *ListStore) ToTreeModel() *TreeModel {
 	return &TreeModel{
 		C.toGTreeModelFromListStore(v.GListStore)}
-}*/
+}
+
 /*func (v *GtkTreeModel) ToListStore() *GtkListStore {
 	return &ListStore{
 		C.toGListStoreFromTreeModel(v.GTreeModel)}


### PR DESCRIPTION
There are two primary issues solved within this pull request.

1. gtk.ListStore cannot be turned into a gtk.TreeModel, this prevents the gtk.ComboBox.SetModel() method from being useful
1. gtk.ComboBoxText has no sane means of accessing it's underlying gtk.Entry widget, the recommended means is via recasting the widget instance returned from gtk.ComboBox.GetChild() - however because the underlying type is not an interface, recasting in the normal Go way is quite cumbersome and I failed to even make it work at all 